### PR TITLE
fix: XML closing tag in makeAppXml function

### DIFF
--- a/src/writer.ts
+++ b/src/writer.ts
@@ -817,7 +817,7 @@ function makeWorkbookXml(worksheets: Worksheet[]) {
 function makeAppXml() {
   return (
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
-    '<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"' +
+    '<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">' +
     "<Application>xlsx-kaku</Application>" +
     "<Manager></Manager>" +
     "<Company></Company>" +


### PR DESCRIPTION
An error occurred when opening the Excel file because a tag in app.xml was not closed.