### PR TITLE
fix: clarify the col params

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ async function main() {
   const ws = wb.addWorksheet("Sheet1");
 
   // The width of only column A will be changed.
-  ws.setColWidth({ min: 1, max: 1, width: 12 });
+  ws.setColWidth({ startIndex: 0, endIndex: 0, width: 12 });
 
   // The width of columns B to C will be changed.
-  ws.setColWidth({ min: 2, max: 3, width: 24 });
+  ws.setColWidth({ startIndex: 1, endIndex: 2, width: 24 });
 
   // The style of column D will be changed.
   ws.setColStyle({
-    min: 4,
-    max: 4,
+    startIndex: 3,
+    endIndex: 3,
     style: { fill: { patternType: "solid", fgColor: "FFFFFF00" } },
   });
 

--- a/src/col.ts
+++ b/src/col.ts
@@ -3,22 +3,22 @@ import { CellStyle } from "./sheetData";
 export const DEFAULT_COL_WIDTH = 9;
 
 export type ColWidth = {
-  min: number;
-  max: number;
+  startIndex: number;
+  endIndex: number;
   width: number;
 };
 
 export type ColStyle = {
-  min: number;
-  max: number;
+  startIndex: number;
+  endIndex: number;
   style: CellStyle;
 };
 
 export type Col = ColWidth | ColStyle;
 
 export type CombinedCol = {
-  min: number;
-  max: number;
+  startIndex: number;
+  endIndex: number;
   width?: number;
   style?: CellStyle;
 };
@@ -28,7 +28,7 @@ export function combineColProps(cols: Col[]): CombinedCol[] {
   const combinedCols: CombinedCol[] = [];
   for (const col of cols) {
     const found = combinedCols.find(
-      (c) => c.min === col.min && c.max === col.max
+      (c) => c.startIndex === col.startIndex && c.endIndex === col.endIndex
     );
     if (found) {
       if ("width" in col) {
@@ -40,8 +40,8 @@ export function combineColProps(cols: Col[]): CombinedCol[] {
     }
 
     const newCombinedCol: CombinedCol = {
-      min: col.min,
-      max: col.max,
+      startIndex: col.startIndex,
+      endIndex: col.endIndex,
     };
     if ("width" in col) {
       newCombinedCol.width = col.width;

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -302,8 +302,8 @@ export function convertCombinedColToXlsxCol(
   }
 
   return {
-    min: col.min,
-    max: col.max,
+    min: col.startIndex + 1,
+    max: col.endIndex + 1,
     width: col.width ?? DEFAULT_COL_WIDTH,
     customWidth: col.width !== undefined && col.width !== DEFAULT_COL_WIDTH,
     cellXfId: cellXfId,

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -32,7 +32,9 @@ type StyleMappers = {
 };
 
 type XlsxCol = {
+  /** e.g. column A is 1 */
   min: number;
+  /** e.g. column A is 1 */
   max: number;
   width: number;
   customWidth: boolean;

--- a/tests/col.test.ts
+++ b/tests/col.test.ts
@@ -3,20 +3,29 @@ import { Col, combineColProps } from "../src/col";
 describe("col", () => {
   test("combineColProps", () => {
     const cols: Col[] = [
-      { min: 1, max: 2, width: 10 },
-      { min: 1, max: 2, style: { alignment: { horizontal: "center" } } },
-      { min: 3, max: 4, width: 20 },
-      { min: 3, max: 4, style: { alignment: { vertical: "top" } } },
+      { startIndex: 0, endIndex: 1, width: 10 },
+      {
+        startIndex: 0,
+        endIndex: 1,
+        style: { alignment: { horizontal: "center" } },
+      },
+      { startIndex: 2, endIndex: 3, width: 20 },
+      { startIndex: 2, endIndex: 3, style: { alignment: { vertical: "top" } } },
     ];
     const combinedCols = combineColProps(cols);
     expect(combinedCols).toEqual([
       {
-        min: 1,
-        max: 2,
+        startIndex: 0,
+        endIndex: 1,
         width: 10,
         style: { alignment: { horizontal: "center" } },
       },
-      { min: 3, max: 4, width: 20, style: { alignment: { vertical: "top" } } },
+      {
+        startIndex: 2,
+        endIndex: 3,
+        width: 20,
+        style: { alignment: { vertical: "top" } },
+      },
     ]);
   });
 });

--- a/tests/integration/colStyle.test.ts
+++ b/tests/integration/colStyle.test.ts
@@ -34,13 +34,13 @@ describe("col style", () => {
     const ws = wb.addWorksheet("Sheet1");
 
     ws.setColStyle({
-      min: 1,
-      max: 1,
+      startIndex: 0,
+      endIndex: 0,
       style: { fill: { patternType: "solid", fgColor: "FFFFFF00" } },
     });
     ws.setColStyle({
-      min: 3,
-      max: 5,
+      startIndex: 2,
+      endIndex: 4,
       style: { fill: { patternType: "solid", fgColor: "FFFF0000" } },
     });
 

--- a/tests/integration/colStyle1.test.ts
+++ b/tests/integration/colStyle1.test.ts
@@ -34,13 +34,13 @@ describe("col style with cell value", () => {
     const ws = wb.addWorksheet("Sheet1");
 
     ws.setColStyle({
-      min: 1,
-      max: 1,
+      startIndex: 0,
+      endIndex: 0,
       style: { fill: { patternType: "solid", fgColor: "FFFFFF00" } },
     });
     ws.setColStyle({
-      min: 3,
-      max: 3,
+      startIndex: 2,
+      endIndex: 2,
       style: { fill: { patternType: "solid", fgColor: "FFFF0000" } },
     });
 

--- a/tests/integration/cols.test.ts
+++ b/tests/integration/cols.test.ts
@@ -40,8 +40,8 @@ describe("cols", () => {
     ws.setCell(0, 5, { type: "number", value: 6 });
 
     // In online Excel, I set the width to 25, but in the saved styles.xml, it is 25.625.
-    ws.setColWidth({ min: 2, max: 2, width: 25.625 });
-    ws.setColWidth({ min: 3, max: 5, width: 6.625 });
+    ws.setColWidth({ startIndex: 1, endIndex: 1, width: 25.625 });
+    ws.setColWidth({ startIndex: 2, endIndex: 4, width: 6.625 });
 
     await wb.save(actualXlsxPath);
 

--- a/tests/writer.test.ts
+++ b/tests/writer.test.ts
@@ -368,9 +368,9 @@ describe("Writer", () => {
       worksheetRels: new WorksheetRels(),
     };
     const cols: Col[] = [
-      { min: 1, max: 1, width: 10 },
-      { min: 2, max: 2, width: 75 },
-      { min: 3, max: 6, width: 25 },
+      { startIndex: 0, endIndex: 0, width: 10 },
+      { startIndex: 1, endIndex: 1, width: 75 },
+      { startIndex: 2, endIndex: 5, width: 25 },
     ];
 
     const xlsxCols = combineColProps(cols).map((col) =>
@@ -394,7 +394,9 @@ describe("Writer", () => {
       hyperlinks: new Hyperlinks(),
       worksheetRels: new WorksheetRels(),
     };
-    const cols: Col[] = [{ min: 1, max: 1, width: DEFAULT_COL_WIDTH }];
+    const cols: Col[] = [
+      { startIndex: 0, endIndex: 0, width: DEFAULT_COL_WIDTH },
+    ];
 
     const xlsxCols = combineColProps(cols).map((col) =>
       convertCombinedColToXlsxCol(col, styleMappers)
@@ -418,17 +420,21 @@ describe("Writer", () => {
       worksheetRels: new WorksheetRels(),
     };
     const cols: Col[] = [
-      { min: 1, max: 1, style: { alignment: { horizontal: "center" } } },
       {
-        min: 2,
-        max: 3,
+        startIndex: 0,
+        endIndex: 0,
+        style: { alignment: { horizontal: "center" } },
+      },
+      {
+        startIndex: 1,
+        endIndex: 2,
         style: {
           fill: { patternType: "solid", fgColor: "FFFF0000" },
         },
       },
       {
-        min: 2,
-        max: 3,
+        startIndex: 1,
+        endIndex: 2,
         width: 25,
       },
     ];


### PR DESCRIPTION
The issue where the parameters for setting the column are unclear will be fixed. 
Similar to setCell, a zero-based index will be passed.

before
```
// The width of only column A will be changed.
ws.setColWidth({ min: 1, max: 1, width: 12 });

// The style of column D will be changed.
ws.setColStyle({
  min: 4,
  max: 4,
  style: { fill: { patternType: "solid", fgColor: "FFFFFF00" } },
});
```

after
```
// The width of only column A will be changed.
ws.setColWidth({ startIndex: 0, endIndex: 0, width: 12 });

// The style of column D will be changed.
ws.setColStyle({
  startIndex: 3,
  endIndex: 3,
  style: { fill: { patternType: "solid", fgColor: "FFFFFF00" } },
});
```