### PR TITLE
refactor: change freezePane type to target

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ async function main() {
   ws.setCell(1, 1, { type: "number", value: 4 });
 
   // the first row will be fixed.
-  ws.setFreezePane({ type: "row", split: 1 });
+  ws.setFreezePane({ target: "row", split: 1 });
 
   // Column A will be fixed.
-  // ws.setFreezePane({ type: "column", split: 1 });
+  // ws.setFreezePane({ target: "column", split: 1 });
 
   await wb.save("test.xlsx");
 }

--- a/src/worksheet.ts
+++ b/src/worksheet.ts
@@ -15,7 +15,7 @@ export type MergeCell = {
 };
 
 export type FreezePane = {
-  type: "column" | "row";
+  target: "column" | "row";
   split: number;
 };
 

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -372,7 +372,7 @@ export function makeSheetViewsXml(
     return result;
   }
 
-  switch (freezePane.type) {
+  switch (freezePane.target) {
     case "column": {
       let result =
         "<sheetViews>" +
@@ -398,7 +398,7 @@ export function makeSheetViewsXml(
       return result;
     }
     default: {
-      const _exhaustiveCheck: never = freezePane.type;
+      const _exhaustiveCheck: never = freezePane.target;
       throw new Error(`unknown freezePane type: ${_exhaustiveCheck}`);
     }
   }

--- a/tests/integration/freezePane0.test.ts
+++ b/tests/integration/freezePane0.test.ts
@@ -43,7 +43,7 @@ describe("freeze pane 0", () => {
     ws.setCell(2, 1, { type: "number", value: 8 });
     ws.setCell(2, 2, { type: "number", value: 9 });
 
-    ws.setFreezePane({ type: "column", split: 1 });
+    ws.setFreezePane({ target: "column", split: 1 });
 
     await wb.save(actualXlsxPath);
 

--- a/tests/integration/freezePane1.test.ts
+++ b/tests/integration/freezePane1.test.ts
@@ -43,7 +43,7 @@ describe("freeze pane 1", () => {
     ws.setCell(2, 1, { type: "number", value: 8 });
     ws.setCell(2, 2, { type: "number", value: 9 });
 
-    ws.setFreezePane({ type: "row", split: 1 });
+    ws.setFreezePane({ target: "row", split: 1 });
 
     await wb.save(actualXlsxPath);
 

--- a/tests/writer.test.ts
+++ b/tests/writer.test.ts
@@ -468,7 +468,7 @@ describe("Writer", () => {
 
   test("mekeSheetViewsXml with frozen column", () => {
     const dimension = { start: "A1", end: "B2" };
-    const freezePane: FreezePane = { type: "column", split: 1 };
+    const freezePane: FreezePane = { target: "column", split: 1 };
     expect(makeSheetViewsXml(dimension, freezePane)).toBe(
       `<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane ySplit="1" topLeftCell="A2" activePane="bottomLeft" state="frozen"/><selection pane="bottomLeft" activeCell="A1" sqref="A1"/></sheetView></sheetViews>`
     );
@@ -476,7 +476,7 @@ describe("Writer", () => {
 
   test("mekeSheetViewsXml with frozen row", () => {
     const dimension = { start: "A1", end: "B2" };
-    const freezePane: FreezePane = { type: "row", split: 1 };
+    const freezePane: FreezePane = { target: "row", split: 1 };
     expect(makeSheetViewsXml(dimension, freezePane)).toBe(
       `<sheetViews><sheetView tabSelected="1" workbookViewId="0"><pane xSplit="1" topLeftCell="B1" activePane="topRight" state="frozen"/><selection pane="topRight" activeCell="A1" sqref="A1"/></sheetView></sheetViews>`
     );


### PR DESCRIPTION
Clarify feezePane props.

before
```
// the first row will be fixed.
ws.setFreezePane({ type: "row", split: 1 });
```

after
```
// the first row will be fixed.
ws.setFreezePane({ target: "row", split: 1 });
```
